### PR TITLE
Fixes workflow consistency module issue

### DIFF
--- a/KInspector.Modules/Scripts/WorkflowConsistencyGetDocuments.sql
+++ b/KInspector.Modules/Scripts/WorkflowConsistencyGetDocuments.sql
@@ -6,4 +6,4 @@
 )
 SELECT *
 FROM versions
-WHERE rn = 1 and WasPublishedFrom IS NOT NULL
+WHERE rn = 1 and WasPublishedFrom IS NOT NULL and DocumentForeignKeyValue IS NOT NULL


### PR DESCRIPTION
The module will fail if the documents have no foreign key but are still in the version history table (e.g. CMS.Root or CMS.Folder). This change excludes these document from being checked as they don't have any extra data to be inconsistent anyway.